### PR TITLE
Use gql_type to create top level collections

### DIFF
--- a/graphql/accessor_general.lua
+++ b/graphql/accessor_general.lua
@@ -206,8 +206,8 @@ end
 --- function will search through
 ---
 --- @tparam table from information about a connection bring executor to select
---- from a current collection; it is nil when the executor selecting top-level
---- objects, but has the following structure for nested collections:
+--- from a current collection; its `collection_name` is 'Query' selecting
+--- top-level objects;it has the following structure:
 ---
 ---     {
 ---         collection_name = <...> (string),
@@ -267,7 +267,7 @@ local get_index_name = function(self, collection_name, from, filter, args)
     -- If an offset is set we return it as `pivot.filter`. So, select will be
     -- performed by an index from the connection, then the result will be
     -- postprocessed using `pivot`.
-    if from ~= nil then
+    if from.collection_name ~= 'Query' then
         local connection_index =
             connection_indexes[collection_name][from.connection_name]
         local index_name = connection_index.index_name
@@ -631,8 +631,8 @@ end
 ---
 --- @tparam string collection_name name of collection to perform select
 ---
---- @tparam table from collection and connection names we arrive from/by or nil
---- as defined in the `tarantool_graphql.new` function description
+--- @tparam table from collection and connection names we arrive from/by as
+--- defined in the `tarantool_graphql.new` function description
 ---
 --- @tparam table filter subset of object fields with values by which we want
 --- to find full object(s)
@@ -685,7 +685,7 @@ local function select_internal(self, collection_name, from, filter, args, extra)
     assert(self.funcs.is_collection_exists(collection_name),
         ('cannot find collection "%s"'):format(collection_name))
     local index = self.funcs.get_index(collection_name, index_name)
-    if from ~= nil then
+    if from.collection_name ~= 'Query' then
         -- allow fullscan only for a top-level object
         assert(index ~= nil,
             ('cannot find index "%s" in space "%s"'):format(

--- a/graphql/tarantool_graphql.lua
+++ b/graphql/tarantool_graphql.lua
@@ -443,6 +443,45 @@ gql_type = function(state, avro_schema, collection, collection_name)
     end
 end
 
+--- Create virtual root collection `Query`, which has connections to any
+--- collection.
+---
+--- Actually, each GQL query starts its execution from the `Query` collection.
+--- That is why it shoult contain connections to any collection.
+---
+--- @tparam table state dictionary which contains all information about the
+--- schema, arguments, types...
+local function create_root_collection(state)
+    local root_connections = {}
+    -- The fake connections have 1:N mechanics.
+    -- Create one connection for each collection.
+    for collection_name, collection in pairs(state.collections) do
+        table.insert(root_connections, {
+            parts = {},
+            name = collection_name,
+            destination_collection = collection_name,
+            type = "1:N"
+        })
+    end
+    local root_schema = {
+        type = "record",
+        name = "Query",
+        -- The fake root has no fields.
+        fields = {}
+    }
+    local root_collection = {
+        name = "Query",
+        connections = root_connections
+    }
+
+    -- `gql_type` is designed to create GQL type corresponding to a real schema
+    -- and connections. However it also works with the fake schema.
+    local root_type = gql_type(state, root_schema, root_collection, "Query")
+    state.schema = schema.create({
+        query = root_type
+    })
+end
+
 local function parse_cfg(cfg)
     local state = {}
     state.types = utils.gen_booking_table({})
@@ -461,8 +500,11 @@ local function parse_cfg(cfg)
     local collections = table.copy(cfg.collections)
     state.collections = collections
 
-    local fields = {}
-
+    -- Prepare types which represents:
+    --  - Avro schemas (collections)
+    --  - scalar field arguments (used to filter objects by value stored in it's
+    --    field)
+    --  - list arguments (offset, limit...)
     for collection_name, collection in pairs(state.collections) do
         collection.name = collection_name
         assert(collection.schema_name ~= nil,
@@ -495,43 +537,9 @@ local function parse_cfg(cfg)
         state.list_arguments[collection_name] = list_args
         state.all_arguments[collection_name] = args
 
-        -- create entry points from collection names
-        fields[collection_name] = {
-            kind = types.nonNull(types.list(state.types[collection_name])),
-            arguments = state.all_arguments[collection_name],
-            resolve = function(rootValue, args_instance, info)
-                local object_args_instance = {} -- passed to 'filter'
-                local list_args_instance = {} -- passed to 'args'
-                for k, v in pairs(args_instance) do
-                    if list_args[k] ~= nil then
-                        list_args_instance[k] = v
-                    elseif state.object_arguments[k] ~= nil then
-                        object_args_instance[k] = v
-                    else
-                        error(('cannot found "%s" field ("%s" value) ' ..
-                            'within allowed fields'):format(tostring(k),
-                            tostring(v)))
-                    end
-                end
-                local from = nil
-
-                local extra = {
-                    qcontext = info.qcontext
-                }
-                return accessor:select(rootValue, collection_name, from,
-                    object_args_instance, list_args_instance, extra)
-            end,
-        }
     end
-
-    local schema = schema.create({
-        query = types.object({
-            name = 'Query',
-            fields = fields,
-        })
-    })
-    state.schema = schema
-
+    -- create fake root `Query` collection
+    create_root_collection(state)
     return state
 end
 


### PR DESCRIPTION
The commmit introduces the idea that the `Query` object is just a
collection. If so, it is natural to addd this type to GraphQl using
the same procedure as for other types.

This is important change, because it not only deletes current code
duplication, but allows to not repeat yourself during further coding.