### PR TITLE
Support float, double and boolean

### DIFF
--- a/graphql/core/execute.lua
+++ b/graphql/core/execute.lua
@@ -85,7 +85,12 @@ local function getFieldEntry(objectType, object, fields, context)
 
   local arguments = util.map(fieldType.arguments or {}, function(argument, name)
     local supplied = argumentMap[name] and argumentMap[name].value
-    return supplied and util.coerceValue(supplied, argument, context.variables) or argument.defaultValue
+    supplied =  supplied and util.coerceValue(supplied, argument, context.variables)
+    if supplied ~= nil then
+        return supplied
+    else
+        return argument.defaultValue
+    end
   end)
 
   local info = {

--- a/graphql/core/types.lua
+++ b/graphql/core/types.lua
@@ -205,7 +205,7 @@ end
 
 types.int = types.scalar({
   name = 'Int',
-  description = "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ", 
+  description = "The `Int` scalar type represents non-fractional signed whole numeric values. Int can represent values between -(2^31) and 2^31 - 1. ",
   serialize = coerceInt,
   parseValue = coerceInt,
   parseLiteral = function(node)

--- a/test/space/init_fail.test.lua
+++ b/test/space/init_fail.test.lua
@@ -9,14 +9,7 @@ package.path = fio.abspath(debug.getinfo(1).source:match("@?(.*/)")
 
 local graphql = require('graphql')
 local testdata = require('test.testdata.compound_index_testdata')
-
--- utils
--- -----
-
--- return an error w/o file name and line number
-local function strip_error(err)
-    return tostring(err):gsub('^.-:.-: (.*)$', '%1')
-end
+local test_utils = require('test.utils')
 
 -- init box, upload test data and acquire metadata
 -- -----------------------------------------------
@@ -57,7 +50,8 @@ local function create_gql_wrapper(metadata)
 end
 
 local ok, err = pcall(create_gql_wrapper, metadata)
-print(('INIT: ok: %s; err: %s'):format(tostring(ok), strip_error(err)))
+print(('INIT: ok: %s; err: %s'):format(tostring(ok),
+    test_utils.strip_error(err)))
 
 -- restore back cut part
 metadata.collections.order_collection.connections[1].parts[2] = saved_part
@@ -78,7 +72,8 @@ metadata.indexes.user_collection.user_str_index = {
 }
 
 local ok, err = pcall(create_gql_wrapper, metadata)
-print(('INIT: ok: %s; err: %s'):format(tostring(ok), strip_error(err)))
+print(('INIT: ok: %s; err: %s'):format(tostring(ok),
+    test_utils.strip_error(err)))
 
 -- restore metadata back
 metadata.indexes.user_collection.user_str_index = nil

--- a/test/testdata/compound_index_testdata.lua
+++ b/test/testdata/compound_index_testdata.lua
@@ -2,13 +2,9 @@ local tap = require('tap')
 local json = require('json')
 local yaml = require('yaml')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 
 local compound_index_testdata = {}
-
--- return an error w/o file name and line number
-local function strip_error(err)
-    return tostring(err):gsub('^.-:.-: (.*)$', '%1')
-end
 
 -- schemas and meta-information
 -- ----------------------------
@@ -1238,7 +1234,7 @@ function compound_index_testdata.run_queries(gql_wrapper)
         return gql_query_4:execute(variables_4_2)
     end)
 
-    local result_4_2 = {ok = ok, err = strip_error(err)}
+    local result_4_2 = {ok = ok, err = test_utils.strip_error(err)}
 
     local exp_result_4_2 = yaml.decode(([[
         ---
@@ -1325,7 +1321,7 @@ function compound_index_testdata.run_queries(gql_wrapper)
         return gql_query_5:execute(variables_5_2)
     end)
 
-    local result_5_2 = {ok = ok, err = strip_error(err)}
+    local result_5_2 = {ok = ok, err = test_utils.strip_error(err)}
 
     local exp_result_5_2 = yaml.decode(([[
         ---

--- a/test/testdata/nullable_1_1_conn_testdata.lua
+++ b/test/testdata/nullable_1_1_conn_testdata.lua
@@ -9,16 +9,12 @@ local tap = require('tap')
 local json = require('json')
 local yaml = require('yaml')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 
 local nullable_1_1_conn_testdata = {}
 
 local PRNG_SEED = 42
 local DOMAIN = 'graphql.tarantool.org'
-
--- return an error w/o file name and line number
-local function strip_error(err)
-    return tostring(err):gsub('^.-:.-: (.*)$', '%1')
-end
 
 function nullable_1_1_conn_testdata.get_test_metadata()
     local schemas = json.decode([[{
@@ -411,7 +407,7 @@ function nullable_1_1_conn_testdata.run_queries(gql_wrapper)
         return gql_query_upside:execute(variables_upside_x)
     end)
 
-    local result = {ok = ok, err = strip_error(err)}
+    local result = {ok = ok, err = test_utils.strip_error(err)}
     local exp_result = yaml.decode(([[
         ---
         ok: false
@@ -429,7 +425,7 @@ function nullable_1_1_conn_testdata.run_queries(gql_wrapper)
         return gql_query_upside:execute(variables_upside_y)
     end)
 
-    local result = {ok = ok, err = strip_error(err)}
+    local result = {ok = ok, err = test_utils.strip_error(err)}
     local exp_result = yaml.decode(([[
         ---
         ok: false

--- a/test/testdata/nullable_index_testdata.lua
+++ b/test/testdata/nullable_index_testdata.lua
@@ -6,13 +6,9 @@ local tap = require('tap')
 local json = require('json')
 local yaml = require('yaml')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 
 local nullable_index_testdata = {}
-
--- return an error w/o file name and line number
-local function strip_error(err)
-    return tostring(err):gsub('^.-:.-: (.*)$', '%1')
-end
 
 function nullable_index_testdata.get_test_metadata()
     local schemas = json.decode([[{
@@ -243,7 +239,7 @@ function nullable_index_testdata.run_queries(gql_wrapper)
         return gql_query_1:execute(variables_1)
     end)
 
-    local result = {ok = ok, err = strip_error(err)}
+    local result = {ok = ok, err = test_utils.strip_error(err)}
     local exp_result = yaml.decode(([[
         ---
         ok: false

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -25,6 +25,11 @@ function utils.print_and_return(...)
     return table.concat({ ... }, ' ') .. '\n'
 end
 
+-- return an error w/o file name and line number
+function utils.strip_error(err)
+    return tostring(err):gsub('^.-:.-: (.*)$', '%1')
+end
+
 function utils.graphql_from_testdata(testdata, shard, graphql_opts)
     local graphql_opts = graphql_opts or {}
     local meta = testdata.meta or testdata.get_test_metadata()


### PR DESCRIPTION
Float and double are forbidden in arguments to prevent compare of
floating-point number for equality (it is very error prone). Boolean are
allowed to be in arguments.

Fixed false boolean argument bug in graphql-lua.

Fixes #31.