### PR TITLE
Fix flaky test fails

### DIFF
--- a/test/shard_servers/shard.lua
+++ b/test/shard_servers/shard.lua
@@ -11,10 +11,12 @@ end
 -- start console first
 require('console').listen(os.getenv('ADMIN'))
 
-box.cfg({
-    listen = instance_uri(INSTANCE_ID),
-})
+box.cfg({})
 
 box.once('shard_init', function()
     box.schema.user.grant('guest', 'read,write,execute', 'universe')
 end)
+
+box.cfg({
+    listen = instance_uri(INSTANCE_ID),
+})


### PR DESCRIPTION
Don't listen for incoming connections on a storage until grants is set
up.