### PR TITLE
Support avro-schema-3* (updated tests)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,8 @@ dist: trusty
 env:
     - SHARD_VERSION=1.2 AVRO_SCHEMA=2.3.2
     - SHARD_VERSION=2.1 AVRO_SCHEMA=2.3.2
+    - SHARD_VERSION=1.2 AVRO_SCHEMA=3.0.0
+    - SHARD_VERSION=2.1 AVRO_SCHEMA=3.0.0
 
 branches:
   only:

--- a/README.md
+++ b/README.md
@@ -155,7 +155,7 @@ make test
 * For use:
   * tarantool,
   * lulpeg,
-  * >=tarantool/avro-schema-2.0-71-gfea0ead (but < 3.0.0),
+  * >=tarantool/avro-schema-2.0-71-gfea0ead,
   * >=tarantool/shard-1.1-91-gfa88bf8 (but < 2.0) or
     >=tarantool/shard-2.1-0-g0a7d98f (optional),
   * lrexlib-pcre2 or lrexlib-pcre (optional),
@@ -164,7 +164,7 @@ make test
   * python 2.7,
   * virtualenv,
   * luacheck,
-  * >=tarantool/avro-schema-2.2.2-4-g1145e3e (but < 3.0.0),
+  * >=tarantool/avro-schema-2.2.2-4-g1145e3e,
   * >=tarantool/shard-1.1-92-gec1a27e (but < 2.0) or
     >=tarantool/shard-2.1-0-g0a7d98f,
   * tarantool/http.

--- a/test/extra/to_avro_nested.test.lua
+++ b/test/extra/to_avro_nested.test.lua
@@ -17,7 +17,7 @@ box.cfg{wal_mode="none"}
 test:plan(4)
 
 data.init_spaces()
-data.fill_test_data(box.space)
+data.fill_test_data(box.space, data.meta)
 
 local accessor = graphql.accessor_space.new({
     schemas = data.meta.schemas,

--- a/test/extra/to_avro_nullable.test.lua
+++ b/test/extra/to_avro_nullable.test.lua
@@ -16,8 +16,8 @@ box.cfg{wal_mode="none"}
 test:plan(4)
 
 testdata.init_spaces()
-testdata.fill_test_data()
 local meta = testdata.get_test_metadata()
+testdata.fill_test_data(box.space, meta)
 
 local accessor = graphql.accessor_space.new({
     schemas = meta.schemas,

--- a/test/space/nested_args.test.lua
+++ b/test/space/nested_args.test.lua
@@ -11,6 +11,7 @@ local tap = require('tap')
 local yaml = require('yaml')
 local graphql = require('graphql')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 local common_testdata = require('test.testdata.common_testdata')
 local emails_testdata = require('test.testdata.nullable_1_1_conn_testdata')
 
@@ -23,12 +24,16 @@ common_testdata.init_spaces()
 emails_testdata.init_spaces()
 
 -- upload test data
-common_testdata.fill_test_data()
-emails_testdata.fill_test_data()
+local common_meta = common_testdata.meta or common_testdata.get_test_metadata()
+local emails_meta = emails_testdata.meta or emails_testdata.get_test_metadata()
+common_testdata.fill_test_data(box.space, common_meta)
+emails_testdata.fill_test_data(box.space, emails_meta)
+
+local avro_version = test_utils.major_avro_schema_version()
 
 local LOCALPART_FN = 1
 local DOMAIN_FN = 2
-local BODY_FN = 7
+local BODY_FN = avro_version == 3 and 5 or 7
 
 for _, tuple in box.space.email:pairs() do
     local body = tuple[BODY_FN]

--- a/test/space/server.test.lua
+++ b/test/space/server.test.lua
@@ -18,7 +18,8 @@ box.cfg{background = false}
 testdata.init_spaces()
 
 -- upload test data
-testdata.fill_test_data()
+local meta = testdata.meta or testdata.get_test_metadata()
+testdata.fill_test_data(box.space, meta)
 
 -- acquire metadata
 local metadata = testdata.get_test_metadata()

--- a/test/space/unflatten_tuple.test.lua
+++ b/test/space/unflatten_tuple.test.lua
@@ -21,15 +21,15 @@ local testdata = require('test.testdata.common_testdata')
 box.cfg{background = false}
 testdata.init_spaces()
 
--- upload test data
-testdata.fill_test_data()
-
 -- acquire metadata
 local metadata = testdata.get_test_metadata()
 local schemas = metadata.schemas
 local collections = metadata.collections
 local service_fields = metadata.service_fields
 local indexes = metadata.indexes
+
+-- upload test data
+testdata.fill_test_data(box.space, metadata)
 
 -- build accessor and graphql schemas
 -- ----------------------------------

--- a/test/testdata/avro_refs_testdata.lua
+++ b/test/testdata/avro_refs_testdata.lua
@@ -8,6 +8,7 @@ local tap = require('tap')
 local json = require('json')
 local yaml = require('yaml')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 
 local testdata = {}
 
@@ -94,25 +95,51 @@ function testdata.drop_spaces()
     box.space.foo:drop()
 end
 
-function testdata.fill_test_data(virtbox)
-    local NULL_T = 0
-    local VALUE_T = 1
-
+function testdata.fill_test_data(virtbox, meta)
     local x = 1000
     local y = 2000
     local a = 3000
     local b = 4000
 
-    -- non-null bar, baz and its refs
-    virtbox.foo:replace({1,                       -- id
-        x, y, x, y, VALUE_T, {x, y},              -- bar & refs
-        VALUE_T, {a, b}, a, b, VALUE_T, {a, b},   -- baz & refs
-    })
-    -- null in nullable bar, baz refs
-    virtbox.foo:replace({2,                       -- id
-        x, y, x, y, NULL_T, box.NULL,             -- bar & refs
-        NULL_T, box.NULL, a, b, NULL_T, box.NULL, -- baz & refs
-    })
+    local avro_version = test_utils.major_avro_schema_version()
+
+    if avro_version == 3 then
+        -- non-null bar, baz and its refs
+        test_utils.replace_object(virtbox, meta, 'foo', {
+            id = 1,
+            bar = {x = x, y = y},
+            bar_ref = {x = x, y = y},
+            bar_nref = {x = x, y = y},
+            baz = {x = a, y = b},
+            baz_ref = {x = a, y = b},
+            baz_nref = {x = a, y = b},
+        })
+        -- null in nullable bar, baz refs
+        test_utils.replace_object(virtbox, meta, 'foo', {
+            id = 2,
+            bar = {x = x, y = y},
+            bar_ref = {x = x, y = y},
+            bar_nref = box.NULL,
+            baz = box.NULL,
+            baz_ref = {x = a, y = b},
+            baz_nref = box.NULL,
+        })
+    else
+        -- flatten does not work properly in the case of avro-schema-2.3.2
+        local NULL_T = 0
+        local VALUE_T = 1
+
+        -- non-null bar, baz and its refs
+        virtbox.foo:replace({1,                       -- id
+            x, y, x, y, VALUE_T, {x, y},              -- bar & refs
+            VALUE_T, {a, b}, a, b, VALUE_T, {a, b},   -- baz & refs
+        })
+        -- null in nullable bar, baz refs
+        virtbox.foo:replace({2,                       -- id
+            x, y, x, y, NULL_T, box.NULL,             -- bar & refs
+            NULL_T, box.NULL, a, b, NULL_T, box.NULL, -- baz & refs
+        })
+    end
 end
 
 function testdata.run_queries(gql_wrapper)

--- a/test/testdata/common_testdata.lua
+++ b/test/testdata/common_testdata.lua
@@ -151,41 +151,88 @@ function common_testdata.init_spaces()
     end)
 end
 
-function common_testdata.fill_test_data(shard)
-    local shard = shard or box.space
+function common_testdata.fill_test_data(virtbox, meta)
+    test_utils.replace_object(virtbox, meta, 'user_collection', {
+        user_id = 'user_id_1',
+        first_name = 'Ivan',
+        middle_name = 'Ivanovich',
+        last_name = 'Ivanov',
+    }, {
+        1827767717,
+    })
+    test_utils.replace_object(virtbox, meta, 'user_collection', {
+        user_id = 'user_id_2',
+        first_name = 'Vasiliy',
+        middle_name = box.NULL,
+        last_name = 'Pupkin',
+    }, {
+        1827767717,
+    })
 
-    local NULL_T = 0
-    local STRING_T = 1
-
-    shard.user_collection:replace(
-        {1827767717, 'user_id_1', 'Ivan', STRING_T, 'Ivanovich', 'Ivanov'})
-    shard.user_collection:replace(
-        {1827767717, 'user_id_2', 'Vasiliy', NULL_T, box.NULL, 'Pupkin'})
-    shard.order_collection:replace(
-        {'order_id_1', 'user_id_1', 'first order of Ivan', 0, 0, true})
-    shard.order_collection:replace(
-        {'order_id_2', 'user_id_1', 'second order of Ivan', 0, 0, false})
-    shard.order_collection:replace(
-        {'order_id_3', 'user_id_2', 'first order of Vasiliy', 0, 0, true})
+    test_utils.replace_object(virtbox, meta, 'order_collection', {
+        order_id = 'order_id_1',
+        user_id = 'user_id_1',
+        description = 'first order of Ivan',
+        price = 0,
+        discount = 0,
+        in_stock = true,
+    })
+    test_utils.replace_object(virtbox, meta, 'order_collection', {
+        order_id = 'order_id_2',
+        user_id = 'user_id_1',
+        description = 'second order of Ivan',
+        price = 0,
+        discount = 0,
+        in_stock = false,
+    })
+    test_utils.replace_object(virtbox, meta, 'order_collection', {
+        order_id = 'order_id_3',
+        user_id = 'user_id_2',
+        description = 'first order of Vasiliy',
+        price = 0,
+        discount = 0,
+        in_stock = true,
+    })
 
     for i = 3, 100 do
         local s = tostring(i)
-        shard.user_collection:replace(
-            {1827767717, 'user_id_' .. s, 'first name ' .. s, NULL_T, box.NULL,
-            'last name ' .. s})
+        test_utils.replace_object(virtbox, meta, 'user_collection', {
+            user_id = 'user_id_' .. s,
+            first_name = 'first name ' .. s,
+            middle_name = box.NULL,
+            last_name = 'last name ' .. s,
+        }, {
+            1827767717,
+        })
         for j = (4 + (i - 3) * 40), (4 + (i - 2) * 40) - 1 do
             local t = tostring(j)
-            shard.order_collection:replace({
-                'order_id_' .. t, 'user_id_' .. s, 'order of user ' .. s,
-                i + j / 3, i + j / 3, j % 2 == 1,
+            test_utils.replace_object(virtbox, meta, 'order_collection', {
+                order_id = 'order_id_' .. t,
+                user_id = 'user_id_' .. s,
+                description = 'order of user ' .. s,
+                price = i + j / 3,
+                discount = i + j / 3,
+                in_stock = j % 2 == 1,
             })
         end
     end
 
-    shard.user_collection:replace(
-        {1827767717, 'user_id_101', 'Иван', STRING_T, 'Иванович', 'Иванов'})
-    shard.order_collection:replace(
-        {'order_id_3924', 'user_id_101', 'Покупка 3924', 0, 0, true})
+    test_utils.replace_object(virtbox, meta, 'user_collection', {
+        user_id = 'user_id_101',
+        first_name = 'Иван',
+        middle_name = 'Иванович',
+        last_name = 'Иванов',
+    }, {
+        1827767717,
+    })
+    test_utils.replace_object(virtbox, meta, 'order_collection', {
+        order_id = 'order_id_3924',
+        user_id = 'user_id_101',
+        description = 'Покупка 3924',
+        price = 0,
+        discount = 0,
+        in_stock = true,
+    })
 end
 
 function common_testdata.drop_spaces()

--- a/test/testdata/nested_record_testdata.lua
+++ b/test/testdata/nested_record_testdata.lua
@@ -6,6 +6,7 @@ local tap = require('tap')
 local json = require('json')
 local yaml = require('yaml')
 local utils = require('graphql.utils')
+local test_utils = require('test.utils')
 
 local testdata = {}
 
@@ -68,14 +69,22 @@ function testdata.drop_spaces()
     box.space.user:drop()
 end
 
-function testdata.fill_test_data(virtbox)
+function testdata.fill_test_data(virtbox, meta)
     for i = 1, 15 do
         local uid = i
         local p1 = 'p1 ' .. tostring(i)
         local p2 = 'p2 ' .. tostring(i)
         local x = 1000 + i
         local y = 2000 + i
-        virtbox.user:replace({uid, p1, p2, x, y})
+        test_utils.replace_object(virtbox, meta, 'user', {
+            uid = uid,
+            p1 = p1,
+            p2 = p2,
+            nested = {
+                x = x,
+                y = y,
+            }
+        })
     end
 end
 

--- a/test/testdata/nullable_index_testdata.lua
+++ b/test/testdata/nullable_index_testdata.lua
@@ -114,15 +114,15 @@ function nullable_index_testdata.get_test_metadata()
     }
 end
 
-function nullable_index_testdata.init_spaces()
+function nullable_index_testdata.init_spaces(avro_version)
     -- foo fields
     local FOO_ID_FN = 1
 
     -- bar fields
     local BAR_ID_FN = 1
-    local BAR_ID_OR_NULL_1_FN = 3
-    local BAR_ID_OR_NULL_2_FN = 5
-    local BAR_ID_OR_NULL_3_FN = 7
+    local BAR_ID_OR_NULL_1_FN = avro_version == 3 and 2 or 3
+    local BAR_ID_OR_NULL_2_FN = avro_version == 3 and 3 or 5
+    local BAR_ID_OR_NULL_3_FN = avro_version == 3 and 4 or 7
 
     box.once('test_space_init_spaces', function()
         box.schema.create_space('foo')
@@ -153,64 +153,146 @@ function nullable_index_testdata.init_spaces()
     end)
 end
 
-function nullable_index_testdata.fill_test_data(shard)
-    local shard = shard or box.space
-
-    local NULL_T = 0
-    local STRING_T = 1
-
+function nullable_index_testdata.fill_test_data(virtbox, meta)
     for i = 1, 114 do
         local s = tostring(i)
-        shard.foo:replace({s, s, s, s})
+        test_utils.replace_object(virtbox, meta, 'foo', {
+            id = s,
+            bar_id_1 = s,
+            bar_id_2 = s,
+            data = s,
+        })
     end
     -- str, str, str
     for i = 1, 100 do
         local s = tostring(i)
-        shard.bar:replace({s, STRING_T, s, STRING_T, s, STRING_T, s, s})
+        test_utils.replace_object(virtbox, meta, 'bar', {
+            id = s,
+            id_or_null_1 = s,
+            id_or_null_2 = s,
+            id_or_null_3 = s,
+            data = s,
+        })
     end
     -- null, str, str
     local s = '101'
-    shard.bar:replace({s, NULL_T, box.NULL, STRING_T, s, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = s,
+        id_or_null_3 = s,
+        data = s,
+    })
     local s = '102'
-    shard.bar:replace({s, NULL_T, box.NULL, STRING_T, s, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = s,
+        id_or_null_3 = s,
+        data = s,
+    })
     -- str, null, str
     local s = '103'
-    shard.bar:replace({s, STRING_T, s, NULL_T, box.NULL, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = s,
+        data = s,
+    })
     local s = '104'
-    shard.bar:replace({s, STRING_T, s, NULL_T, box.NULL, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = s,
+        data = s,
+    })
     -- str, str, null
     local s = '105'
-    shard.bar:replace({s, STRING_T, s, STRING_T, s, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = s,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     local s = '106'
-    shard.bar:replace({s, STRING_T, s, STRING_T, s, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = s,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     -- null, null, str
     local s = '107'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, NULL_T, box.NULL, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = s,
+        data = s,
+    })
     local s = '108'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, NULL_T, box.NULL, STRING_T, s, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = s,
+        data = s,
+    })
     -- null, str, null
     local s = '109'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, STRING_T, s, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = s,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     local s = '110'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, STRING_T, s, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = s,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     -- str, null, null
     local s = '111'
-    shard.bar:replace(
-        {s, STRING_T, s, NULL_T, box.NULL, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     local s = '112'
-    shard.bar:replace(
-        {s, STRING_T, s, NULL_T, box.NULL, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = s,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     -- null, null, null
     local s = '113'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, NULL_T, box.NULL, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
     local s = '114'
-    shard.bar:replace(
-        {s, NULL_T, box.NULL, NULL_T, box.NULL, NULL_T, box.NULL, s})
+    test_utils.replace_object(virtbox, meta, 'bar', {
+        id = s,
+        id_or_null_1 = box.NULL,
+        id_or_null_2 = box.NULL,
+        id_or_null_3 = box.NULL,
+        data = s,
+    })
 end
 
 function nullable_index_testdata.drop_spaces()

--- a/test/utils.lua
+++ b/test/utils.lua
@@ -6,6 +6,7 @@ local fio = require('fio')
 package.path = fio.abspath(debug.getinfo(1).source:match("@?(.*/)")
     :gsub('/./', '/'):gsub('/+$', '')) .. '/../?.lua' .. ';' .. package.path
 
+local avro_schema = require('avro_schema')
 local graphql = require('graphql')
 local multirunner = require('test.common.multirunner')
 local graphql_utils = require('graphql.utils')
@@ -13,6 +14,78 @@ local test_run = graphql_utils.optional_require('test_run')
 test_run = test_run and test_run.new()
 
 local utils = {}
+
+-- module-local variables
+local models_cache
+
+-- simplified version of the same named function from accessor_general.lua
+function utils.compile_schemas(schemas, service_fields)
+    local service_fields_types = {}
+    for name, service_fields_list in pairs(service_fields) do
+        local sf_types = {}
+        local sf_defaults = {}
+        for _, v in ipairs(service_fields_list) do
+            sf_types[#sf_types + 1] = v.type
+            sf_defaults[#sf_defaults + 1] = v.default
+        end
+        service_fields_types[name] = sf_types
+    end
+
+    local models = {}
+    for name, schema in pairs(schemas) do
+        local ok, handle = avro_schema.create(schema)
+        assert(ok)
+        local sf_types = service_fields_types[name]
+        local ok, model = avro_schema.compile(
+            {handle, service_fields = sf_types})
+        assert(ok)
+        models[name] = model
+    end
+    return models
+end
+
+local function get_model(meta, collection_name)
+    local schema_name = meta.collections[collection_name].schema_name
+    assert(schema_name ~= nil)
+    if models_cache == nil then
+        models_cache = utils.compile_schemas(meta.schemas,
+            meta.service_fields)
+    end
+    local model = models_cache[schema_name]
+    -- We don't handle case when there are two testdata modules with the
+    -- same-named schemas within the one test; the result will be incorrect in
+    -- the case.
+    if model == nil then
+        models_cache = utils.compile_schemas(meta.schemas,
+            meta.service_fields)
+        model = models_cache[schema_name]
+    end
+    assert(model ~= nil)
+    return model
+end
+
+function utils.flatten_object(meta, collection_name, object,
+        service_field_values)
+    local model = get_model(meta, collection_name)
+    local ok, tuple = model.flatten(object, unpack(service_field_values or {}))
+    assert(ok, tostring(tuple))
+    return tuple
+end
+
+function utils.replace_object(virtbox, meta, collection_name, object,
+        service_field_values)
+    local tuple = utils.flatten_object(meta, collection_name, object,
+        service_field_values)
+    virtbox[collection_name]:replace(tuple)
+end
+
+function utils.major_avro_schema_version()
+    local ok, handle = avro_schema.create('boolean')
+    assert(ok)
+    local ok, model = avro_schema.compile(handle)
+    assert(ok)
+    return model.get_types == nil and 2 or 3
+end
 
 -- return an error w/o file name and line number
 function utils.strip_error(err)
@@ -48,13 +121,16 @@ function utils.run_testdata(testdata, opts)
     multirunner.run_conf(conf_name, {
         test_run = test_run,
         init_function = testdata.init_spaces,
+        init_function_params = {utils.major_avro_schema_version()},
         cleanup_function = testdata.drop_spaces,
         workload = function(_, shard)
             local virtbox = shard or box.space
-            testdata.fill_test_data(virtbox)
+            local meta = testdata.meta or testdata.get_test_metadata()
+            testdata.fill_test_data(virtbox, meta)
             local gql_wrapper = utils.graphql_from_testdata(testdata, shard,
                 opts.graphql_opts)
-            run_queries(gql_wrapper)
+            run_queries(gql_wrapper, virtbox, meta)
+            models_cache = nil -- clear models cache
         end,
         servers = {'shard1', 'shard2', 'shard3', 'shard4'},
         use_tcp = false,


### PR DESCRIPTION
Changed only tests where a data layout is different between
avro-schema-2* and avro-schema-3*.

The avro_refs test triggers a flatten bug in avro-schema-2.3.2, so the
data flattened manually in the case. The bug is not reported, because it
is recomended to move to avro-schema-3* to use record*.

Fixes #150.