### PR TITLE
Fix GraphiQL warning on the pcre argument

### DIFF
--- a/graphql/accessor_general.lua
+++ b/graphql/accessor_general.lua
@@ -15,6 +15,7 @@ if rex == nil then
     -- fallback to libpcre
     rex, is_pcre2 = utils.optional_require('rex_pcre'), false
 end
+local avro_helpers = require('graphql.avro_helpers')
 
 -- XXX: consider using [1] when it will be mature enough;
 -- look into [2] for the status.
@@ -1215,7 +1216,10 @@ local function get_pcre_argument_type(self, collection_name)
 
     for _, field in ipairs(schema.fields) do
         if field.type == 'string' or field.type == 'string*' then
-            string_fields[#string_fields + 1] = table.copy(field)
+            local field = table.copy(field)
+            field.type = avro_helpers.make_avro_type_nullable(
+                field.type, {raise_on_nullable = false})
+            table.insert(string_fields, field)
         end
     end
 

--- a/graphql/avro_helpers.lua
+++ b/graphql/avro_helpers.lua
@@ -1,0 +1,74 @@
+--- The module us collection of helpers to simplify avro-schema related tasks.
+
+local json = require('json')
+
+local avro_helpers = {}
+
+--- The function converts avro type to the corresponding nullable type in
+--- place and returns the result.
+---
+--- We make changes in place in case of table input (`avro`) because of
+--- performance reasons, but we returns the result because an input (`avro`)
+--- can be a string. Strings in Lua are immutable.
+---
+--- In the current tarantool/avro-schema implementation we simply add '*' to
+--- the end of a type name or, in case of union, add 'null' branch.
+---
+--- If the type is already nullable the function leaves it as is if
+--- `opts.raise_on_nullable` is false or omitted. If `opts.raise_on_nullable`
+--- is true the function will raise an error.
+---
+--- @tparam table avro avro schema node to be converted to nullable one
+---
+--- @tparam[opt] table opts the following options:
+---
+--- * `raise_on_nullable` (boolean) raise an error on nullable type
+---
+--- @result `result` (string or table) nullable avro type
+function avro_helpers.make_avro_type_nullable(avro, opts)
+    assert(avro ~= nil, "avro must not be nil")
+    local opts = opts or {}
+    assert(type(opts) == 'table',
+        'opts must be nil or a table, got ' .. type(opts))
+    local raise_on_nullable = opts.raise_on_nullable or false
+    assert(type(raise_on_nullable) == 'boolean',
+        'opts.raise_on_nullable must be nil or a boolean, got ' ..
+        type(raise_on_nullable))
+
+    local value_type = type(avro)
+
+    if value_type == "string" then
+        local is_nullable = avro:endswith("*")
+        if raise_on_nullable and is_nullable then
+            error('expected non-null type, got the nullable one: ' ..
+                json.encode(avro))
+        end
+        return is_nullable and avro or (avro .. '*')
+    elseif value_type == 'table' and #avro > 0 then -- union
+        local is_nullable = false
+        for _, branch in ipairs(avro) do
+            if branch == 'null' then
+                is_nullable = true
+                break
+            end
+        end
+        if raise_on_nullable and is_nullable then
+            error('expected non-null type, got the nullable one: ' ..
+                json.encode(avro))
+        end
+        -- We add 'nil' branch to the end because here we don't know whether
+        -- the following things matter for a caller:
+        -- * a default value (it must have the type of the first branch);
+        -- * {,un,x}flatten data layout.
+        if not is_nullable then
+            table.insert(avro, 'null')
+        end
+        return avro
+    elseif value_type == 'table' and #avro == 0 then
+        return avro_helpers.make_avro_type_nullable(avro.type, opts)
+    end
+
+    error("avro should be a string or a table, got " .. value_type)
+end
+
+return avro_helpers

--- a/test/common/pcre.test.lua
+++ b/test/common/pcre.test.lua
@@ -14,7 +14,7 @@ local testdata = require('test.testdata.common_testdata')
 
 local function run_queries(gql_wrapper)
     local test = tap.test('pcre')
-    test:plan(3)
+    test:plan(4)
 
     local query_1 = [[
         query users($offset: String, $first_name_re: String,
@@ -95,6 +95,33 @@ local function run_queries(gql_wrapper)
     ]]):strip())
 
     test:is_deeply(result_1_3, exp_result_1_3, '1_3')
+
+    -- }}}
+
+    -- {{{ regexp match with immediate arguments
+
+    local query_1i = [[
+        query users {
+            user_collection(pcre: {
+                first_name: "(?i)^i",
+                middle_name: "ich$",
+            }) {
+                first_name
+                middle_name
+                last_name
+            }
+        }
+    ]]
+
+    local gql_query_1i = utils.show_trace(function()
+        return gql_wrapper:compile(query_1i)
+    end)
+
+    local result_1i_1 = utils.show_trace(function()
+        return gql_query_1i:execute({})
+    end)
+
+    test:is_deeply(result_1i_1, exp_result_1_1, '1i_1')
 
     -- }}}
 


### PR DESCRIPTION
The problem was in incorrect schema: sub-arguments of the pcre argument
for non-null strings was generated as non-null that triggers a warning
in GraphiQL in case when the sub-argument is omitted. Graphql-lua
(graphql/core/validate.lua) does not check for this kind of
inconsistency between a schema and a query, so lack of the sub-argument
works as expected in test/common/pcre.test.lua.

The added test with immediate sub-arguments of the pcre argument does
not catch the bug, but I decided to leave it in the commit.

Fixes #156.