### PR TITLE
Implement `make demo` to expose testdata via HTTP

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,7 @@ apidoc:
 .PHONY: serve-apidoc
 serve-apidoc: apidoc
 	$(WWW_BROWSER) ./doc/apidoc/index.html
+
+.PHONY: demo
+demo:
+	./demo/demo.lua $(TESTDATA)

--- a/demo/demo.lua
+++ b/demo/demo.lua
@@ -1,0 +1,42 @@
+#!/usr/bin/env tarantool
+
+local fio = require('fio')
+
+-- require in-repo version of graphql/ sources despite current working directory
+package.path =
+    fio.abspath(debug.getinfo(1).source:match("@?(.*/)")
+    :gsub('/./', '/'):gsub('/+$', '') .. '/../?.lua') .. ';' ..
+    fio.abspath(debug.getinfo(1).source:match("@?(.*/)")
+    :gsub('/./', '/'):gsub('/+$', '') .. '/../?/init.lua') .. ';' ..
+    package.path
+
+local log = require('log')
+local test_utils = require('test.utils')
+
+-- e. g. nullable_1_1_conn
+local testdata_name = arg[1] or 'common'
+-- e. g. test/testdata/nullable_1_1_conn_testdata.lua
+if testdata_name:find('/') then
+    testdata_name = testdata_name:gsub('^.+/(.+)_testdata.lua$', '%1')
+end
+
+local testdata = require(('test.testdata.%s_testdata'):format(testdata_name))
+
+local function start()
+    box.cfg({})
+    local ok, err = pcall(function()
+        testdata.drop_spaces()
+    end)
+    if not ok then
+        log.warn('Cannot drop data: ' .. tostring(err))
+    end
+    local meta = testdata.meta or testdata.get_test_metadata()
+    local avro_version = test_utils.major_avro_schema_version()
+    testdata.init_spaces(avro_version)
+    testdata.fill_test_data(box.space, meta)
+    local gql_wrapper = test_utils.graphql_from_testdata(testdata)
+    local msg = gql_wrapper:start_server()
+    log.info(tostring(msg))
+end
+
+start()


### PR DESCRIPTION
Usage examples:

1. make demo # run common testdata
2. make TESTDATA=nullable_1_1_conn demo
3. make TESTDATA=test/testdata/compound_index_testdata.lua demo