### PR TITLE
Fix Travis CI cron job

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: -n "${OS}"
+      condition: -n "${OS}" && x"${TRAVIS_EVENT_TYPE}" != x"cron"
   - provider: packagecloud
     username: ${PACKAGECLOUD_USER}
     repository: "1_10"
@@ -57,7 +57,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: -n "${OS}"
+      condition: -n "${OS}" && x"${TRAVIS_EVENT_TYPE}" != x"cron"
   - provider: packagecloud
     username: ${PACKAGECLOUD_USER}
     repository: "2_0"
@@ -67,7 +67,7 @@ deploy:
     skip_cleanup: true
     on:
       branch: master
-      condition: -n "${OS}"
+      condition: -n "${OS}" && x"${TRAVIS_EVENT_TYPE}" != x"cron"
 notifications:
   email:
     recipients:


### PR DESCRIPTION
It fails like so:

Pushing package: tarantool-graphql-0.0.1.2-1.fc27.src.rpm
Error {"filename":["has already been taken"]}