### PR TITLE
Fix 'make rpm' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,4 +72,5 @@ demo:
 
 .PHONY: rpm
 rpm:
-	OS=el DIST=7 ./3rd_party/packpack/packpack
+	OS=el DIST=7 PACKAGECLOUD_USER=tarantool PACKAGECLOUD_REPO=1_9 \
+	   ./3rd_party/packpack/packpack


### PR DESCRIPTION
This commit reflects the fact that RPM spec now has build time
dependencies from the tarantool repository.