### PR TITLE
Fix flaky fails with hang tests

### DIFF
--- a/test/bench/suite.ini
+++ b/test/bench/suite.ini
@@ -3,6 +3,7 @@ core = app
 description = microbenchmarking
 config = suite.cfg
 is_parallel = False
+use_unix_sockets = True
 long_run =
     forking-2-100-1.test.lua
     forking-2-1-1.test.lua

--- a/test/common/suite.ini
+++ b/test/common/suite.ini
@@ -3,3 +3,4 @@ core = app
 description = tests different setups simultaneously
 config = suite.cfg
 is_parallel = True
+use_unix_sockets = True

--- a/test/extra/suite.ini
+++ b/test/extra/suite.ini
@@ -3,3 +3,4 @@ core = app
 description = tests on features which are not related to specific executor
 is_parallel = True
 config = suite.cfg
+use_unix_sockets = True

--- a/test/space/suite.ini
+++ b/test/space/suite.ini
@@ -3,3 +3,4 @@ core = app
 description = tests with space accessor
 config = suite.cfg
 is_parallel = False
+use_unix_sockets = True


### PR DESCRIPTION
The problem is that frontend wait infinitely for a storage server, which
have not been initialized due to the error like the following.

```
Start failed: builtin/box/console.lua:560: failed to create server
localhost:57988: Address already in use
```

The problem is described in [1] (see comment itself, the issue is about
the another problem).

The gist of the fix is using unix sockets for admin console of
non-default servers (storages), it is why test-run update is needed. The
option 'use_unix_sockets' affects only console (admin) socket and does
nothing with binary (listen) port of a storage. It is critical in the
benchmarking test suite.

[1]: https://github.com/tarantool/test-run/issues/115#issuecomment-413850864