### PR TITLE
Support to skip union variants in a query

### DIFF
--- a/graphql/query_to_avro.lua
+++ b/graphql/query_to_avro.lua
@@ -160,7 +160,11 @@ union_to_avro = function(fieldType, subSelections, context)
                 break
             end
         end
-        assert(box_sub_selections ~= nil)
+
+        -- Skip Union variants that are not parts of the query.
+        if box_sub_selections == nil then
+            goto continue
+        end
 
         -- We have to extract subSelections from 'box' type.
         local type_sub_selections
@@ -183,6 +187,8 @@ union_to_avro = function(fieldType, subSelections, context)
             table.insert(result, gql_type_to_avro(type.kind,
                 type_sub_selections, context))
         end
+
+        ::continue::
     end
 
     return result

--- a/test/extra/to_avro_multihead.test.lua
+++ b/test/extra/to_avro_multihead.test.lua
@@ -17,7 +17,7 @@ local testdata = require('test.testdata.multihead_conn_with_nulls_testdata')
 
 local test = tap.test('to avro schema')
 
-test:plan(7)
+test:plan(14)
 
 box.cfg{}
 
@@ -32,6 +32,14 @@ local gql_wrapper = graphql.new(utils.merge_tables({
     indexes = meta.indexes,
     accessor = 'space'
 }, test_utils.test_conf_graphql_opts()))
+
+-- The query 'obtainHumans' was added:
+--
+-- * to ensure we allow to write only some of all possible variants in a query;
+-- * to ensure a result does not have a variant skipped in a query and
+--   generated avro-schema reflects such result shape.
+--
+-- More: https://github.com/tarantool/graphql/issues/244
 
 local query = [[
     query obtainHeroes($hero_id: String) {
@@ -67,9 +75,33 @@ local query = [[
             }
         }
     }
+
+    query obtainHumans($hero_id: String) {
+        hero_collection(hero_id: $hero_id) {
+            hero_id
+            hero_type
+            banking_type
+            hero_connection {
+                ... on box_human_collection {
+                    human_collection {
+                        name
+                    }
+                }
+            }
+            hero_banking_connection {
+                ... on box_array_credit_account_collection {
+                    credit_account_collection {
+                        account_id
+                        hero_banking_id
+                    }
+                }
+            }
+        }
+
+    }
 ]]
 
-local expected_avro_schema = [[
+local expected_avro_schema_heroes = [[
     type: record
     name: Query
     fields:
@@ -139,23 +171,77 @@ local expected_avro_schema = [[
           namespace: Query
 ]]
 
+local expected_avro_schema_humans = [[
+    type: record
+    name: Query
+    fields:
+    - name: hero_collection
+      type:
+        type: array
+        items:
+          type: record
+          fields:
+          - name: hero_id
+            type: string
+          - name: hero_type
+            type: string*
+          - name: banking_type
+            type: string*
+          - name: hero_connection
+            type:
+              type: record*
+              name: results___hero_connection
+              fields:
+              - name: human_collection
+                type:
+                  type: record*
+                  fields:
+                  - name: name
+                    type: string
+                  name: human_collection
+                  namespace: Query.hero_collection
+          - name: hero_banking_connection
+            type:
+              type: record*
+              name: results___hero_banking_connection
+              fields:
+              - name: credit_account_collection
+                type:
+                  type: array*
+                  items:
+                    type: record
+                    fields:
+                    - name: account_id
+                      type: string
+                    - name: hero_banking_id
+                      type: string
+                    name: credit_account_collection
+                    namespace: Query.hero_collection
+          name: hero_collection
+          namespace: Query
+]]
+
 local gql_query = gql_wrapper:compile(query)
-local avro_from_query = gql_query:avro_schema()
+local avro_from_query_heroes = gql_query:avro_schema('obtainHeroes')
+local avro_from_query_humans = gql_query:avro_schema('obtainHumans')
 
-expected_avro_schema = yaml.decode(expected_avro_schema)
+expected_avro_schema_heroes = yaml.decode(expected_avro_schema_heroes)
+expected_avro_schema_humans = yaml.decode(expected_avro_schema_humans)
 
-test:is_deeply(avro_from_query, expected_avro_schema,
-    'comparision between expected and generated (from query) avro-schemas')
+test:is_deeply(avro_from_query_heroes, expected_avro_schema_heroes,
+    'avro-schema generated from a query (obtainHeroes)')
+test:is_deeply(avro_from_query_humans, expected_avro_schema_humans,
+    'avro-schema generated from a query (obtainHumans)')
 
-local ok, compiled_schema = avro.create(avro_from_query)
-assert(ok, tostring(compiled_schema))
+local ok, compiled_schema_heroes = avro.create(avro_from_query_heroes)
+assert(ok, tostring(compiled_schema_heroes))
+local ok, compiled_schema_humans = avro.create(avro_from_query_humans)
+assert(ok, tostring(compiled_schema_humans))
 
 local variables_1 = {
     hero_id = 'hero_id_1'
 }
 
-local result_1 = gql_query:execute(variables_1)
-result_1 = result_1.data
 local result_expected_1 = yaml.decode([[
     hero_collection:
     - hero_id: hero_id_1
@@ -174,19 +260,27 @@ local result_expected_1 = yaml.decode([[
             hero_banking_id: hero_banking_id_1
 ]])
 
-test:is_deeply(result_1, result_expected_1,
-    'comparision between expected and actual query response 1')
+-- heroes
+local result_1 = gql_query:execute(variables_1, 'obtainHeroes')
+test:is_deeply(result_1.data, result_expected_1,
+    'query 1 response (obtainHeroes)')
+local ok, err = avro.validate(compiled_schema_heroes, result_1.data)
+test:ok(ok, 'query 1 response validation (obtainHeroes)', {err = err})
 
-local ok, err = avro.validate(compiled_schema, result_1)
-assert(ok, tostring(err))
-test:is(ok, true, 'query response validation by avro 1')
+-- humans
+result_expected_1.hero_collection[1].hero_connection.starship_collection = nil
+result_expected_1.hero_collection[1].hero_banking_connection
+    .dublon_account_collection = nil
+local result_1 = gql_query:execute(variables_1, 'obtainHumans')
+test:is_deeply(result_1.data, result_expected_1,
+    'query 1 response (obtainHumans)')
+local ok, err = avro.validate(compiled_schema_humans, result_1.data)
+test:ok(ok, 'query 1 response validation (obtainHumans)', {err = err})
 
 local variables_2 = {
     hero_id = 'hero_id_2'
 }
 
-local result_2 = gql_query:execute(variables_2)
-result_2 = result_2.data
 local result_expected_2 = yaml.decode([[
     hero_collection:
     - hero_id: hero_id_2
@@ -205,31 +299,46 @@ local result_expected_2 = yaml.decode([[
             hero_banking_id: hero_banking_id_2
 ]])
 
-test:is_deeply(result_2, result_expected_2,
-    'comparision between expected and actual query response 2')
+-- heroes
+local result_2 = gql_query:execute(variables_2, 'obtainHeroes')
+test:is_deeply(result_2.data, result_expected_2,
+    'query 2 response (obtainHeroes)')
+local ok, err = avro.validate(compiled_schema_heroes, result_2.data)
+test:ok(ok, 'query 2 response validation (obtainHeroes)', {err = err})
 
-local ok, err = avro.validate(compiled_schema, result_2)
-assert(ok, tostring(err))
-test:is(ok, true, 'query response validation by avro 2')
+-- humans
+result_expected_2.hero_collection[1].hero_connection.starship_collection = nil
+result_expected_2.hero_collection[1].hero_banking_connection
+    .dublon_account_collection = nil
+local result_2 = gql_query:execute(variables_2, 'obtainHumans')
+print(yaml.encode(result_2.data))
+test:is_deeply(result_2.data, result_expected_2,
+    'query 2 response (obtainHumans)')
+local ok, err = avro.validate(compiled_schema_humans, result_2.data)
+test:ok(ok, 'query 2 response validation (obtainHumans)', {err = err})
 
 local variables_3 = {
     hero_id = 'hero_id_3'
 }
-
-local result_3 = gql_query:execute(variables_3)
-result_3 = result_3.data
 
 local result_expected_3 = yaml.decode([[
     hero_collection:
     - hero_id: hero_id_3
 ]])
 
-test:is_deeply(result_3, result_expected_3,
-    'comparision between expected and actual query response 3')
+-- heroes
+local result_3 = gql_query:execute(variables_3, 'obtainHeroes')
+test:is_deeply(result_3.data, result_expected_3,
+    'query 2 response (obtainHeroes)')
+local ok, err = avro.validate(compiled_schema_heroes, result_3.data)
+test:ok(ok, 'query 3 response validation (obtainHeroes)', {err = err})
 
-local ok, err = avro.validate(compiled_schema, result_3)
-assert(ok, tostring(err))
-test:is(ok, true, 'query response validation by avro 3')
+-- humans
+local result_3 = gql_query:execute(variables_3, 'obtainHumans')
+test:is_deeply(result_3.data, result_expected_3,
+    'query 2 response (obtainHumans)')
+local ok, err = avro.validate(compiled_schema_humans, result_3.data)
+test:ok(ok, 'query 3 response validation (obtainHumans)', {err = err})
 
 testdata.drop_spaces()
 


### PR DESCRIPTION
It also applicable for multihead connections.

Fixes #244.