### PR TITLE
Add an ability to pass the request context to the 'execute' function.

### DIFF
--- a/graphql/accessor_space.lua
+++ b/graphql/accessor_space.lua
@@ -157,6 +157,9 @@ end
 ---
 --- @param key primary key
 ---
+--- @tparam table extra table which contains extra information related to
+--- current select and the whole query
+---
 --- @tparam table statements
 ---
 --- @tparam table opts
@@ -164,7 +167,7 @@ end
 --- * tuple (ignored in accessor_space)
 ---
 --- @treturn cdata/table `tuple`
-local function update_tuple(self, collection_name, key, statements, opts)
+local function update_tuple(self, collection_name, key, _, statements, opts)
     check(self, 'self', 'table')
     local opts = opts or {}
     check(opts, 'opts', 'table')
@@ -179,12 +182,15 @@ end
 ---
 --- @param key primary key
 ---
+--- @tparam table extra table which contains extra information related to
+--- current select and the whole query
+---
 --- @tparam table opts
 ---
 --- * tuple (ignored in accessor_space)
 ---
 --- @treturn cdata tuple
-local function delete_tuple(self, collection_name, key, opts)
+local function delete_tuple(self, collection_name, key, _, opts)
     check(self, 'self', 'table')
     local opts = opts or {}
     check(opts, 'opts', 'table')

--- a/graphql/impl.lua
+++ b/graphql/impl.lua
@@ -37,8 +37,10 @@ local default_instance
 ---
 --- @tparam[opt] string operation_name optional operation name
 ---
+--- @tparam[opt] table request_context option context of the request
+---
 --- @treturn table result of the operation
-local function gql_execute(qstate, variables, operation_name)
+local function gql_execute(qstate, variables, operation_name, request_context)
     assert(qstate.state)
     assert(qstate.query_settings)
     local state = qstate.state
@@ -50,10 +52,11 @@ local function gql_execute(qstate, variables, operation_name)
     check(variables, 'variables', 'table')
     check(operation_name, 'operation_name', 'string', 'nil')
     check(max_batch_size, 'max_batch_size', 'number')
-
+    check(request_context, 'request_context', 'table', 'nil')
     local qcontext = {
         query_settings = qstate.query_settings,
         variables = variables,
+        request_context = request_context,
     }
 
     local traceback


### PR DESCRIPTION
This context is saved in the query context and pass to custom accessor functions