### PR TITLE
test: increase coverage allowed time w/o output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -81,7 +81,7 @@ coverage: lint
 	. ./.env-2.7/bin/activate && \
 		pip install -r ./test-run/requirements.txt && \
 		pip install tarantool && \
-		cd test && ./test-run.py --luacov
+		cd test && ./test-run.py --luacov --no-output-timeout 600
 	find test/var -name luacov.stats.out | xargs -I {} sed \
 		-e 's@/test/[^ /]\+/\.\./\.\./graphql@/graphql@' \
 		-e 's@/test/../graphql@/graphql@' \


### PR DESCRIPTION
The coverage target runs for 13 minutes on Travis-CI and sometimes fails
with 'no output during 120 seconds'. This commit increases this limit to
600 seconds.