### PR TITLE
test: increase timeout for accessor_funcs.test.lua

### DIFF
--- a/test/common/accessor_funcs.test.lua
+++ b/test/common/accessor_funcs.test.lua
@@ -172,6 +172,11 @@ end
 
 box.cfg({})
 
-test_utils.run_testdata(testdata, {run_queries = run_queries})
+test_utils.run_testdata(testdata, {
+    run_queries = run_queries,
+    graphql_opts = {
+        timeout_ms = 10000, -- 10 seconds
+    }
+})
 
 os.exit()


### PR DESCRIPTION
It performs filtering by a connected objects (see 'complex select'
case), so can be slow.