### PR TITLE
travis-ci: fix pull requests from external repos

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -42,7 +42,13 @@ script:
         ./tools/ubuntu.trusty.prepare.sh
         export PATH="${PATH}:$(realpath .)/.rocks/bin"
         make coverage
-        luacov-coveralls --include ^graphql --repo-token "${COVERALLS_TOKEN}"
+        if [ -n "${COVERALLS_TOKEN}" ]; then
+            luacov-coveralls --include ^graphql --repo-token "${COVERALLS_TOKEN}"
+        else
+            echo "Skipped uploading to coveralls.io: no token."
+            echo "It is the normal behaviour for a pull request coming from"
+            echo "another repository."
+        fi
     elif [ "${TARGET}" = pack ]; then
         [ -n "${OS}" ] || exit 1
         [ -n "${DIST}" ] || exit 1


### PR DESCRIPTION
Cited from [1]:

> Encrypted variables are not available to untrusted builds such as pull
> requests coming from another repository.

[1]: https://docs.travis-ci.com/user/environment-variables/#defining-encrypted-variables-in-travisyml